### PR TITLE
Added the php minimal supported version in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
             "email": "igor@wiedler.ch"
         }
     ],
+    "require": {
+        "php": ">=5.4"
+    },
     "autoload": {
         "files": ["src/get_in.php"]
     }


### PR DESCRIPTION
The library uses the callable typehint, so it requires PHP 5.4+
