### PR TITLE
Adding micro-optimization for non-nested keys

### DIFF
--- a/src/get_in.php
+++ b/src/get_in.php
@@ -9,7 +9,7 @@ function get_in(array $array, array $keys, $default = null)
     }
 
     // This is a micro-optimization, it is fast for non-nested keys, but fails for null values
-    if (count($keys) == 1 && isset($array[$keys[0]])) {
+    if (count($keys) === 1 && isset($array[$keys[0]])) {
         return $array[$keys[0]];
     }
 


### PR DESCRIPTION
Optimization taken from https://github.com/facebook/libphutil/blob/master/src/utils/utils.php#L38 (`idx` is being used a _lot_ in their code base & Phabricator)

This makes non-nested access ~20-30% faster, but makes nested access ~20-30% slower (might be lower for higher levels of nesting).

Times were taken on PHP 5.4.11 @ Windows

Gist of benchmark script (Inlined both functions to run both tests in the same run):
https://gist.github.com/AnhNhan/8342353

Gist of output:
https://gist.github.com/AnhNhan/8342343

If you are fine with this trade-off, then pull.

An alternative would be creating a separate function for non-nested access.
